### PR TITLE
double FPS in "Lots of data (no virtualization)" when utilising key in #each

### DIFF
--- a/docs-app/public/docs/3-demos/lots-of-data-no-virtualization.md
+++ b/docs-app/public/docs/3-demos/lots-of-data-no-virtualization.md
@@ -68,7 +68,7 @@ export default class extends Component {
           </tr>
         </thead>
         <tbody>
-          {{#each this.table.rows key='data.db.id' as |row|}}
+          {{#each this.table.rows key="data.db.id" as |row|}}
             <tr class="{{row.countClassName}}">
               {{#each this.table.columns as |column|}}
                 <td>

--- a/docs-app/public/docs/3-demos/lots-of-data-no-virtualization.md
+++ b/docs-app/public/docs/3-demos/lots-of-data-no-virtualization.md
@@ -68,7 +68,7 @@ export default class extends Component {
           </tr>
         </thead>
         <tbody>
-          {{#each this.table.rows as |row|}}
+          {{#each this.table.rows key='data.db.id' as |row|}}
             <tr class="{{row.countClassName}}">
               {{#each this.table.columns as |column|}}
                 <td>


### PR DESCRIPTION
1. See [Lots of data (no virtualization) example in docs](https://ue-table.pages.dev/3-demos/lots-of-data-no-virtualization.md)
 

Before this PR:
<img width="225" alt="Screenshot 2025-03-29 at 10 01 49" src="https://github.com/user-attachments/assets/8928973d-a727-434a-aa76-99cb8ac61a73" />

After this PR:
<img width="231" alt="Screenshot 2025-03-29 at 10 04 51" src="https://github.com/user-attachments/assets/029100c5-fa84-46cd-92ef-d1e7dce4e716" />

ref. https://github.com/ember-template-lint/ember-template-lint/blob/master/docs/rule/require-each-key.md


A bit surprised, as the `require-each-key` rule is not in the recommended of ember-template-lint, and [already in 2015 it was said to be unlikely to be have an effect anymore](https://discuss.emberjs.com/t/new-glimmer-consideration-each-key/8128/10).