### PR TITLE
pass through generics to `ComponentLike`

### DIFF
--- a/table/src/-private/interfaces/column.ts
+++ b/table/src/-private/interfaces/column.ts
@@ -44,7 +44,7 @@ export interface ColumnConfig<T = unknown> {
    * Out-of-the-box, this property isn't used, but the provided type may be
    * a convenience for consumers of the headless table
    */
-  Cell?: ComponentLike;
+  Cell?: ComponentLike<T>;
 
   /**
    * The name or title of the column, shown in the column heading / th


### PR DESCRIPTION
Fixes:
<img width="718" height="147" alt="Screenshot 2025-08-25 at 12 38 36" src="https://github.com/user-attachments/assets/5d017f5b-dcdc-40ff-957a-5a3ffad02561" />
