### PR TITLE
Add generic type parameters for optional strong typing of Options and Cell component for template type checking

### DIFF
--- a/docs-app/public/docs/1-get-started/typescript-and-glint.md
+++ b/docs-app/public/docs/1-get-started/typescript-and-glint.md
@@ -71,6 +71,84 @@ class Demo {
 }
 ```
 
+## Type-Safe Cell Components and Options
+
+The table library supports generic type parameters for strongly-typed Cell components and custom options. This enables full type inference in Glint templates and prevents common errors.
+
+### Basic Usage
+
+By default, all generic parameters are set to `any` for backward compatibility:
+
+```ts
+const table = headlessTable<MyDataType>(this, {
+  columns: () => [...],
+  data: () => myData
+});
+```
+
+### Advanced: Type-Safe Options
+
+To get type safety for custom options passed to cells:
+
+```ts
+import { headlessTable, type ColumnConfig, type CellContext } from '@universal-ember/table';
+
+interface MyData {
+  id: string;
+  name: string;
+}
+
+interface MyOptions {
+  highlightColor?: string;
+  showBadge?: boolean;
+}
+
+interface MyCellArgs extends CellContext<MyData, MyOptions> {
+  // Cell components receive data, column, row, and options
+}
+
+const table = headlessTable<MyData, MyOptions, MyCellArgs>(this, {
+  columns: () => [
+    {
+      key: 'name',
+      name: 'Name',
+      Cell: MyCustomCell, // fully typed!
+      options: ({ row }) => ({
+        highlightColor: row.data.id === 'special' ? 'blue' : 'gray',
+        showBadge: true,
+      }),
+    },
+  ],
+  data: () => myData,
+});
+```
+
+Your Cell component will now have full type inference:
+
+```ts
+import Component from '@glimmer/component';
+
+class MyCustomCell extends Component<MyCellArgs> {
+  get color() {
+    return this.args.options?.highlightColor ?? 'gray';
+  }
+
+  <template>
+    <span style="color: {{this.color}}">
+      {{@row.data.name}}
+      {{#if @options.showBadge}}<span class="badge">!</span>{{/if}}
+    </span>
+  </template>
+}
+```
+
+### CellContext Types
+
+The library provides two context types:
+
+- **`CellConfigContext<T, OptionsType>`**: Used when defining column configurations. Has optional fields (`column?`, `row?`, `options?`) for user convenience.
+- **`CellContext<T, OptionsType>`**: Used for Cell component signatures. Has required fields since they're always provided at runtime.
+
 ## In Templates
 
 [Glint][docs-glint] can be a great choice to help ensure that your code is as bug-free as possible.

--- a/table/src/-private/column.ts
+++ b/table/src/-private/column.ts
@@ -4,7 +4,7 @@ import { isEmpty } from '@ember/utils';
 import type { Row } from './row';
 import type { Table } from './table';
 import type { ContentValue } from '@glint/template';
-import type { ColumnConfig } from './interfaces';
+import type { ColumnConfig, CellOptions, CellConfigContext } from './interfaces';
 
 const DEFAULT_VALUE = '--';
 const DEFAULT_VALUE_KEY = 'defaultValue';
@@ -12,7 +12,7 @@ const DEFAULT_OPTIONS = {
   [DEFAULT_VALUE_KEY]: DEFAULT_VALUE,
 };
 
-export class Column<T = unknown> {
+export class Column<T = unknown, OptionsType = any, CellArgs = any> {
   get Cell() {
     return this.config.Cell;
   }
@@ -27,7 +27,7 @@ export class Column<T = unknown> {
 
   constructor(
     public table: Table<T>,
-    public config: ColumnConfig<T>,
+    public config: ColumnConfig<T, OptionsType, CellArgs>,
   ) {}
 
   @action
@@ -52,16 +52,17 @@ export class Column<T = unknown> {
   }
 
   private getDefaultValue(row: Row<T>) {
-    return this.getOptionsForRow(row)[DEFAULT_VALUE_KEY];
+    const options = this.getOptionsForRow(row) as any;
+    return options[DEFAULT_VALUE_KEY];
   }
 
   @action
-  getOptionsForRow(row: Row<T>) {
+  getOptionsForRow(row?: Row<T>): OptionsType & CellOptions {
     const defaults = DEFAULT_OPTIONS;
 
     return {
       ...defaults,
       ...this.config.options?.({ column: this, row }),
-    };
+    } as OptionsType & CellOptions;
   }
 }

--- a/table/src/-private/interfaces/column.ts
+++ b/table/src/-private/interfaces/column.ts
@@ -5,9 +5,18 @@ import type { ColumnOptionsFor, SignatureFrom } from './plugins';
 import type { Constructor } from '../private-types';
 import type { ComponentLike, ContentValue } from '@glint/template';
 
-export interface CellContext<T> {
-  column: Column<T>;
+// Configuration context (for defining column options) - optional fields for user convenience
+export interface CellConfigContext<T, OptionsType = any> {
+  column?: Column<T, OptionsType>;
+  row?: Row<T>;
+  options?: OptionsType & CellOptions;
+}
+
+// Runtime context (for Cell components) - required fields since they're always provided
+export interface CellContext<T, OptionsType = any> {
+  column: Column<T, OptionsType>;
   row: Row<T>;
+  options?: OptionsType & CellOptions;
 }
 
 type ColumnPluginOption<P = Plugin> = P extends BasePlugin
@@ -21,7 +30,7 @@ export type CellOptions = {
   defaultValue?: string;
 } & Record<string, unknown>;
 
-export interface ColumnConfig<T = unknown> {
+export interface ColumnConfig<T = unknown, OptionsType = any, CellArgs = any> {
   /**
    * the `key` is required for preferences storage, as well as
    * managing uniqueness of the columns in an easy-to-understand way.
@@ -37,14 +46,14 @@ export interface ColumnConfig<T = unknown> {
   /**
    * Optionally provide a function to determine the value of a row at this column
    */
-  value?: (context: CellContext<T>) => ContentValue;
+  value?: (context: CellConfigContext<T>) => ContentValue;
 
   /**
    * Recommended property to use for custom components for each cell per column.
    * Out-of-the-box, this property isn't used, but the provided type may be
    * a convenience for consumers of the headless table
    */
-  Cell?: ComponentLike<CellContext<T>>;
+  Cell?: ComponentLike<CellArgs>;
 
   /**
    * The name or title of the column, shown in the column heading / th
@@ -54,7 +63,7 @@ export interface ColumnConfig<T = unknown> {
   /**
    * Bag of extra properties to pass to Cell via `@options`, if desired
    */
-  options?: (context: CellContext<T>) => CellOptions;
+  options?: (context: CellConfigContext<T>) => OptionsType;
 
   /**
    * Each plugin may provide column options, and provides similar syntax to how

--- a/table/src/-private/interfaces/table.ts
+++ b/table/src/-private/interfaces/table.ts
@@ -1,5 +1,5 @@
 import type { Plugins } from '../../plugins/-private/utils';
-import type { ColumnConfig } from './column';
+import type { ColumnConfig, CellOptions, CellContext } from './column';
 import type { Pagination } from './pagination';
 import type { PreferencesAdapter } from './preferences';
 import type { Selection } from './selection';
@@ -9,13 +9,13 @@ export interface TableMeta {
   totalRowsSelectedCount?: number;
 }
 
-export interface TableConfig<DataType> {
+export interface TableConfig<DataType, OptionsType = any, CellArgs = any> {
   /**
    * Configuration describing how the table will crawl through `data`
    * and render it. Within this `columns` config, there will also be opportunities
    * to set the behavior of columns when rendered
    */
-  columns: () => ColumnConfig<DataType>[];
+  columns: () => ColumnConfig<DataType, OptionsType, CellArgs>[];
   /**
    * The data to render, as described via the `columns` option.
    *

--- a/table/src/-private/js-helper.ts
+++ b/table/src/-private/js-helper.ts
@@ -1,10 +1,10 @@
 import { Table } from './table.ts';
 
-import type { TableConfig } from './interfaces';
+import type { TableConfig, CellContext } from './interfaces';
 
-type Args<T> =
-  | [destroyable: object, options: TableConfig<T>]
-  | [options: TableConfig<T>];
+type Args<T, OptionsType = any, CellArgs = any> =
+  | [destroyable: object, options: TableConfig<T, OptionsType, CellArgs>]
+  | [options: TableConfig<T, OptionsType, CellArgs>];
 
 /**
  * Represents a UI-less version of a table
@@ -23,7 +23,7 @@ type Args<T> =
  * }
  * ```
  */
-export function headlessTable<T = unknown>(options: TableConfig<T>): Table<T>;
+export function headlessTable<T = unknown, OptionsType = any, CellArgs = any>(options: TableConfig<T, OptionsType, CellArgs>): Table<T, OptionsType, CellArgs>;
 
 /**
  * Represents a UI-less version of a table
@@ -42,12 +42,12 @@ export function headlessTable<T = unknown>(options: TableConfig<T>): Table<T>;
  * ```
  *
  */
-export function headlessTable<T = unknown>(
+export function headlessTable<T = unknown, OptionsType = any, CellArgs = any>(
   destroyable: object,
-  options: TableConfig<T>,
-): Table<T>;
+  options: TableConfig<T, OptionsType, CellArgs>,
+): Table<T, OptionsType, CellArgs>;
 
-export function headlessTable<T = unknown>(...args: Args<T>): Table<T> {
+export function headlessTable<T = unknown, OptionsType = any, CellArgs = any>(...args: Args<T, OptionsType, CellArgs>): Table<T, OptionsType, CellArgs> {
   if (args.length === 2) {
     const [destroyable, options] = args;
 
@@ -56,10 +56,10 @@ export function headlessTable<T = unknown>(...args: Args<T>): Table<T> {
      * otherwise individual-property reactivity can be managed on a per-property
      * "thunk"-basis
      */
-    return Table.from<Table<T>>(destroyable, () => options);
+    return Table.from<Table<T, OptionsType, CellArgs>>(destroyable, () => options);
   }
 
   const [options] = args;
 
-  return Table.from<Table<T>>(() => options);
+  return Table.from<Table<T, OptionsType, CellArgs>>(() => options);
 }

--- a/table/src/index.ts
+++ b/table/src/index.ts
@@ -12,6 +12,7 @@ export { deserializeSorts, serializeSorts } from './utils.ts';
  *******************************/
 export type { Column } from './-private/column.ts';
 export type {
+  CellContext,
   ColumnConfig,
   ColumnKey,
   Pagination,

--- a/table/src/plugins/-private/base.ts
+++ b/table/src/plugins/-private/base.ts
@@ -296,10 +296,10 @@ export const preferences = {
  * This works recursively up the plugin tree up until a plugin has no requirements, and then
  * all columns from the table are returned.
  */
-function columnsFor<DataType = any>(
-  table: Table<DataType>,
+function columnsFor<DataType = any, OptionsType = any, CellArgs = any>(
+  table: Table<DataType, OptionsType, CellArgs>,
   requester?: Plugin<any>,
-): Column<DataType>[] {
+): Column<DataType, OptionsType, CellArgs>[] {
   assert(
     `First argument passed to columns.for must be an instance of Table`,
     table[TABLE_KEY],
@@ -417,10 +417,10 @@ export const columns = {
    * If a plugin class is provided, the hierarchy of column list modifications
    * will be respected.
    */
-  next: <Data = unknown>(
-    current: Column<Data>,
+  next: <Data = unknown, OptionsType = any>(
+    current: Column<Data, OptionsType>,
     requester?: Plugin<any>,
-  ): Column<Data> | undefined => {
+  ): Column<Data, OptionsType> | undefined => {
     const columns = requester
       ? columnsFor(current.table, requester)
       : columnsFor(current.table);
@@ -449,10 +449,10 @@ export const columns = {
    * If a plugin class is provided, the hierarchy of column list modifications
    * will be respected.
    */
-  previous: <Data = unknown>(
-    current: Column<Data>,
+  previous: <Data = unknown, OptionsType = any>(
+    current: Column<Data, OptionsType>,
     requester?: Plugin<any>,
-  ): Column<Data> | undefined => {
+  ): Column<Data, OptionsType> | undefined => {
     const columns = requester
       ? columnsFor(current.table, requester)
       : columnsFor(current.table);
@@ -479,10 +479,10 @@ export const columns = {
    * if a plugin class is provided, the hierarchy of column list modifications
    * will be respected.
    */
-  before: <Data = unknown>(
-    current: Column<Data>,
+  before: <Data = unknown, OptionsType = any>(
+    current: Column<Data, OptionsType>,
     requester?: Plugin<any>,
-  ): Column<Data>[] => {
+  ): Column<Data, OptionsType>[] => {
     const columns = requester
       ? columnsFor(current.table, requester)
       : columnsFor(current.table);
@@ -498,10 +498,10 @@ export const columns = {
    * if a plugin class is provided, the hierarchy of column list modifications
    * will be respected.
    */
-  after: <Data = unknown>(
-    current: Column<Data>,
+  after: <Data = unknown, OptionsType = any>(
+    current: Column<Data, OptionsType>,
     requester?: Plugin<any>,
-  ): Column<Data>[] => {
+  ): Column<Data, OptionsType>[] => {
     const columns = requester
       ? columnsFor(current.table, requester)
       : columnsFor(current.table);
@@ -767,7 +767,7 @@ function getPluginInstance<Instance>(
   factory: () => Instance,
 ): Instance;
 function getPluginInstance<RootKey extends Column<any> | Row<any>, Instance>(
-  map: WeakMap<Column | Row, Map<Class<Instance>, Instance>>,
+  map: WeakMap<Column<any> | Row<any>, Map<Class<Instance>, Instance>>,
   rootKey: RootKey,
   mapKey: Class<Instance>,
   factory: () => Instance,
@@ -776,13 +776,13 @@ function getPluginInstance<RootKey extends Column<any> | Row<any>, Instance>(
   ...args:
     | [FactoryMap<Instance>, Class<Instance>, () => Instance]
     | [
-        WeakMap<Column | Row, FactoryMap<Instance>>,
+        WeakMap<Column<any> | Row<any>, FactoryMap<Instance>>,
         RootKey,
         Class<Instance>,
         () => Instance,
       ]
 ): Instance {
-  let map: WeakMap<Column | Row, FactoryMap<Instance>> | FactoryMap<Instance>;
+  let map: WeakMap<Column<any> | Row<any>, FactoryMap<Instance>> | FactoryMap<Instance>;
   let mapKey: Class<Instance>;
   let rootKey: RootKey | undefined;
   let factory: () => Instance;


### PR DESCRIPTION
## Summary
  - Adds generic type parameters (`OptionsType` and `CellArgs`) throughout the table system for improved type safety
  - Enables strongly-typed Cell component arguments for better Glint/TypeScript inference
  - Splits `CellContext` into two types: `CellConfigContext` (for configuration) and `CellContext` (for runtime)
  - Exports `CellContext` as part of the public API

## Motivation
When defining custom Cell components with custom options, there was no way to get proper type safety in Glint. This change allows developers to specify the exact shape of their Cell component arguments and options, enabling full type inference in templates.

## Changes
  - `Table`, `Column`, `TableConfig`, `ColumnConfig`, and `headlessTable` now accept `OptionsType` and `CellArgs` generic parameters
  - `CellContext` split into:
    - `CellConfigContext<T, OptionsType>`: For defining column options (optional fields for user convenience)
    - `CellContext<T, OptionsType>`: For Cell components (required fields since they're always provided at runtime)
  - `CellContext` exported from the public API for easier type annotations

  ## Example Usage
  ```ts
  interface MyOptions {
    customField: string;
    anotherField: number;
  }

  interface MyCellArgs {
    data: MyDataType;
    column: Column<MyDataType, MyOptions>;
    options: MyOptions;
  }

  const table = headlessTable<MyDataType, MyOptions, MyCellArgs>(this, {
    columns: () => [{
      key: 'custom',
      Cell: MyCustomCell, // now fully typed!
      options: ({ row }) => ({
        customField: row.data.value,
        anotherField: 42
      })
    }],
    data: () => myData
  });

# Breaking Changes

None - the new generic parameters default to any, maintaining backward compatibility.