### PR TITLE
pass through optional `DataType` generic to columns in `new ColumnOrder`

### DIFF
--- a/table/src/plugins/column-reordering/plugin.ts
+++ b/table/src/plugins/column-reordering/plugin.ts
@@ -217,7 +217,7 @@ export class TableMeta {
  * @private
  * Used for keeping track of and updating column order
  */
-export class ColumnOrder {
+export class ColumnOrder<DataType = unknown> {
   /**
    * This map will be empty until we re-order something.
    */
@@ -237,7 +237,7 @@ export class ColumnOrder {
        * - Provide `visibleColumns` to indicate which are visible
        * - Hidden columns maintain their position when toggled
        */
-      columns: () => Column[];
+      columns: () => Column<DataType>[];
       /**
        * Optional: Record of which columns are currently visible.
        * When provided, moveLeft/moveRight will skip over hidden columns.


### PR DESCRIPTION
Fixes:

<img width="1097" height="356" alt="Screenshot 2025-10-13 at 09 25 09" src="https://github.com/user-attachments/assets/ae5c3746-bf9d-446d-a166-2bb2dee5a2b2" />
