### PR TITLE
Prevent auto-redistributing with tableLayout: 'fixed' 

### DIFF
--- a/table/src/plugins/column-resizing/plugin.ts
+++ b/table/src/plugins/column-resizing/plugin.ts
@@ -374,6 +374,11 @@ export class TableMeta {
       entry.target instanceof HTMLElement,
     );
 
+    // For fixed layout, columns have explicit widths and should not be auto-redistributed
+    if (this.options?.tableLayout === 'fixed') {
+      return;
+    }
+
     this.scrollContainerWidth = getAccurateClientWidth(entry.target);
     this.scrollContainerHeight = getAccurateClientHeight(entry.target);
 


### PR DESCRIPTION
Added early return optimization for tableLayout: 'fixed' since fixed since fixed-layout columns have explicit widths and shouldn't be auto-redistributed.