### PR TITLE
fix: mark touchstart listener as passive in resize handle

### DIFF
--- a/table/src/plugins/column-resizing/handle.ts
+++ b/table/src/plugins/column-resizing/handle.ts
@@ -59,7 +59,9 @@ class ResizeHandle<DataType = unknown> extends Modifier<{
   }
 
   setup = () => {
-    this.dragHandle.addEventListener('touchstart', this.dragStartHandler);
+    this.dragHandle.addEventListener('touchstart', this.dragStartHandler, {
+      passive: true,
+    });
     this.dragHandle.addEventListener('mousedown', this.dragStartHandler);
     this.dragHandle.addEventListener('keydown', this.keyHandler);
 


### PR DESCRIPTION
## Summary
  - Mark `touchstart` event listener as passive in column resize handle to eliminate Chrome console warnings about scroll-blocking events:
  
<img width="1684" height="22" alt="Screenshot 2025-12-03 at 11 55 02" src="https://github.com/user-attachments/assets/acc4814b-e39b-4c5c-9062-d1c6d1776cc9" />


## Notes
Touch events are currently not handled by the resize logic (filtered out by instanceof check), so this change has no functional impact. If proper touch support is needed later, consider using `touch-action: none` CSS instead.
