### PR TITLE
Fix ColumnResizing preferences not restoring saved widths

### DIFF
--- a/table/src/plugins/column-resizing/plugin.ts
+++ b/table/src/plugins/column-resizing/plugin.ts
@@ -359,7 +359,7 @@ export class TableMeta {
     const tablePrefs = this.table.preferences;
 
     for (const column of visibleColumnMetas) {
-      const existing = tablePrefs.storage.forPlugin('ColumnResizing');
+      const existing = tablePrefs.storage.forPlugin(ColumnResizing.name);
       const columnPrefs = existing.forColumn(column.key);
 
       columnPrefs.set('width', column.width.toString());


### PR DESCRIPTION
## Summary
Fix column widths not being restored from preferences adapter

  ## Problem
  `saveColWidths` (line 362) used a hardcoded `'ColumnResizing'` string:
```ts
  const existing = tablePrefs.storage.forPlugin('ColumnResizing');
```
  But the restore path in preferences.forColumn (base.ts:182) uses:
```ts
  const existing = prefs.storage.forPlugin(klass.name);
```

  When bundlers mangle class names, ColumnResizing.name becomes something like '_ColumnResizing', causing a mismatch:
  - Save: writes to plugins.ColumnResizing.columns...
  - Restore: reads from plugins._ColumnResizing.columns...

  ## Fix

  Use ColumnResizing.name consistently for both save and restore.